### PR TITLE
[PQ-1022] [Refactor] Update arg to categories instead of category.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="singer-python",
-      version='5.12.4',
+      version='5.12.5',
       description="Singer.io utility library",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -195,8 +195,8 @@ def parse_args(required_config_keys):
         help='Do schema discovery')
     
     parser.add_argument(
-        '--category',
-        help='Single category to sync')
+        '--categories',
+        help='Comma separated categories to sync')
     
     parser.add_argument(
         '--streams',


### PR DESCRIPTION
# Description
Renames `category` command line argument to `categories`.

## Reference Ticket
-  [pq functions full resync, sync category, delete_records — Finvision Exact Online 100+ divisions](https://www.notion.so/peliqan/pq-functions-full-resync-sync-category-delete_records-Finvision-Exact-Online-100-divisions-a6c52e5c9e5c44f39187996a4e9c7195?pvs=4)

## Change Type
⬜  New feature (non-breaking change which adds functionality)
⬜  Bug fix (non-breaking change which fixes an issue)
✅  Refactor
⬜  Breaking change (fix or feature that would cause existing functionality to not work as expected) 
⬜  This change requires a documentation update
