### PR TITLE
[PQ-1170] [Feat] Accept additional args param1 to param6 in cli command.

### DIFF
--- a/singer/utils.py
+++ b/singer/utils.py
@@ -206,32 +206,32 @@ def parse_args(required_config_keys):
 
     parser.add_argument(
         '--param1',
-        help='Attribute from a Peliqan server instance'
+        help='Attribute from a Peliqan connection instance'
     )
 
     parser.add_argument(
         '--param2',
-        help='Attribute from a Peliqan server instance'
+        help='Attribute from a Peliqan connection instance'
     )
 
     parser.add_argument(
         '--param3',
-        help='Attribute from a Peliqan server instance'
+        help='Attribute from a Peliqan connection instance'
     )
 
     parser.add_argument(
         '--param4',
-        help='Attribute from a Peliqan server instance'
+        help='Attribute from a Peliqan connection instance'
     )
 
     parser.add_argument(
         '--param5',
-        help='Attribute from a Peliqan server instance'
+        help='Attribute from a Peliqan connection instance'
     )
 
     parser.add_argument(
         '--param6',
-        help='Attribute from a Peliqan server instance'
+        help='Attribute from a Peliqan connection instance'
     )
 
     parser.add_argument(

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -175,32 +175,69 @@ def parse_args(required_config_keys):
     parser.add_argument(
         '-c', '--config',
         help='Config file',
-        required=True)
+        required=True
+    )
 
     parser.add_argument(
         '-s', '--state',
-        help='State file')
+        help='State file'
+    )
 
     parser.add_argument(
         '-p', '--properties',
-        help='Property selections: DEPRECATED, Please use --catalog instead')
+        help='Property selections: DEPRECATED, Please use --catalog instead'
+    )
 
     parser.add_argument(
         '--catalog',
-        help='Catalog file')
+        help='Catalog file'
+    )
 
     parser.add_argument(
         '-d', '--discover',
         action='store_true',
-        help='Do schema discovery')
+        help='Do schema discovery'
+    )
     
     parser.add_argument(
         '--categories',
-        help='Comma separated categories to sync')
-    
+        help='Comma separated categories to sync'
+    )
+
+    parser.add_argument(
+        '--param1',
+        help='Attribute from a Peliqan server instance'
+    )
+
+    parser.add_argument(
+        '--param2',
+        help='Attribute from a Peliqan server instance'
+    )
+
+    parser.add_argument(
+        '--param3',
+        help='Attribute from a Peliqan server instance'
+    )
+
+    parser.add_argument(
+        '--param4',
+        help='Attribute from a Peliqan server instance'
+    )
+
+    parser.add_argument(
+        '--param5',
+        help='Attribute from a Peliqan server instance'
+    )
+
+    parser.add_argument(
+        '--param6',
+        help='Attribute from a Peliqan server instance'
+    )
+
     parser.add_argument(
         '--streams',
-        help='Selected streams to sync')
+        help='Selected streams to sync'
+    )
 
     args = parser.parse_args()
     if args.config:


### PR DESCRIPTION
# Description
We need the ability to override param1 to param6 config values in tap-peliqan. When running a pipeline from a script. Therefore, it is necessary for us to add them as allowed args in singer.

## Reference Ticket
-  [pq.run_pipeline() set param1 … param6](https://www.notion.so/peliqan/pq-run_pipeline-set-param1-param6-1041aa9b3879809b931de9a69d554109?pvs=4)

## Additional Notes
- Nothing

## To Do
- Nothing

## Downstream dependencies
- The new cli variables will be available to all singer taps. However, they are only used by the peliqan-tap.

## Test Cases
- Can access the new variables in tap-peliqan

## Change Type
✅  New feature (non-breaking change which adds functionality)
⬜  Bug fix (non-breaking change which fixes an issue)
⬜  Refactor
⬜  Breaking change (fix or feature that would cause existing functionality to not work as expected) 
⬜  This change requires a documentation update