### PR TITLE
[tap-peliqan-#100] [Refactor] Suppress warning

### DIFF
--- a/singer/transform.py
+++ b/singer/transform.py
@@ -25,7 +25,7 @@ def string_to_datetime(value):
     try:
         return strftime(strptime_to_utc(value))
     except Exception as ex:
-        LOGGER.warning("%s, (%s)", ex, value)
+        # LOGGER.warning("%s, (%s)", ex, value)
         return None
 
 


### PR DESCRIPTION
# Description
This PR suppresses the warning thrown when datetime transformation fails. 

## Reference Ticket
-  closes https://github.com/Peliqan-io/tap-peliqan/issues/100

## Additional Notes
- Nothing.

## To Do
- Nothing.

## Downstream dependencies
- Nothing.

## Test Cases
- [x] Warning is no longer logged.

## Change Type
⬜  DevOps
⬜  New feature (non-breaking change which adds functionality)
⬜  Bug fix (non-breaking change which fixes an issue)
✅  Refactor
⬜  Breaking change (fix or feature that would cause existing functionality to not work as expected) 
⬜  This change requires a documentation update